### PR TITLE
Update OpenAPI spec to 3.1

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -60,7 +60,26 @@ info:
     When using this tool you may see browser security warnings due to your browser not trusting the self-signed certificate the plugin will generate on its first run.  If you do, you can make those errors disappear by adding the certificate as a "Trusted Certificate" in your browser or operating system's settings.
   title: "Local REST API for Obsidian"
   version: "1.0"
-openapi: "3.0.2"
+openapi: "3.1.0"
+servers:
+  - description: "HTTPS (Secure Mode)"
+    url: "https://{host}:{port}"
+    variables:
+      host:
+        default: "127.0.0.1"
+        description: "Binding host"
+      port:
+        default: "27124"
+        description: "HTTPS port"
+  - description: "HTTP (Insecure Mode)"
+    url: "http://{host}:{port}"
+    variables:
+      host:
+        default: "127.0.0.1"
+        description: "Binding host"
+      port:
+        default: "27123"
+        description: "HTTP port"
 paths:
   /:
     get:
@@ -96,6 +115,7 @@ paths:
           description: "Success"
       summary: |
         Returns basic details about the server.
+      operationId: get_root
       tags:
         - "System"
   /active/:
@@ -119,6 +139,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Deletes the currently-active file in Obsidian.
+      operationId: delete_active
       tags:
         - "Active File"
     get:
@@ -145,6 +166,7 @@ paths:
           description: "File does not exist"
       summary: |
         Return the content of the active file open in Obsidian.
+      operationId: get_active
       tags:
         - "Active File"
     patch:
@@ -363,6 +385,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Partially update content in the currently open note.
+      operationId: patch_active
       tags:
         - "Active File"
     post:
@@ -400,6 +423,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Append content to the active file open in Obsidian.
+      operationId: post_active
       tags:
         - "Active File"
     put:
@@ -450,6 +474,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Update the content of the active file open in Obsidian.
+      operationId: put_active
       tags:
         - "Active File"
   /commands/:
@@ -479,6 +504,7 @@ paths:
           description: "A list of available commands."
       summary: |
         Get a list of available commands.
+      operationId: get_commands
       tags:
         - "Commands"
   "/commands/{commandId}/":
@@ -501,6 +527,7 @@ paths:
           description: "The command you specified does not exist."
       summary: |
         Execute a command.
+      operationId: post_commands_commandId
       tags:
         - "Commands"
   /obsidian-local-rest-api.crt:
@@ -510,6 +537,7 @@ paths:
           description: "Success"
       summary: |
         Returns the certificate in use by this API.
+      operationId: get_obsidian_local_rest_apicrt
       tags:
         - "System"
   "/open/{filename}":
@@ -537,6 +565,7 @@ paths:
           description: "Success"
       summary: |
         Open the specified document in the Obsidian user interface.
+      operationId: post_open_filename
       tags:
         - "Open"
   /openapi.yaml:
@@ -546,6 +575,7 @@ paths:
           description: "Success"
       summary: |
         Returns OpenAPI YAML document describing the capabilities of this API.
+      operationId: get_openapiyaml
       tags:
         - "System"
   "/periodic/{period}/":
@@ -582,6 +612,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Delete the current periodic note for the specified period.
+      operationId: delete_periodic_period
       tags:
         - "Periodic Notes"
     get:
@@ -617,6 +648,7 @@ paths:
           description: "File does not exist"
       summary: |
         Get current periodic note for the specified period.
+      operationId: get_periodic_period
       tags:
         - "Periodic Notes"
     patch:
@@ -848,6 +880,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Partially update content in the current periodic note for the specified period.
+      operationId: patch_periodic_period
       tags:
         - "Periodic Notes"
     post:
@@ -896,6 +929,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Append content to the current periodic note for the specified period.
+      operationId: post_periodic_period
       tags:
         - "Periodic Notes"
     put:
@@ -959,6 +993,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Update the content of the current periodic note for the specified period.
+      operationId: put_periodic_period
       tags:
         - "Periodic Notes"
   "/periodic/{period}/{year}/{month}/{day}/":
@@ -1015,6 +1050,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Delete the periodic note for the specified period and date.
+      operationId: delete_periodic_period_year_month_day
       tags:
         - "Periodic Notes"
     get:
@@ -1068,6 +1104,7 @@ paths:
           description: "File does not exist"
       summary: |
         Get the periodic note for the specified period and date.
+      operationId: get_periodic_period_year_month_day
       tags:
         - "Periodic Notes"
     patch:
@@ -1317,6 +1354,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Partially update content in the periodic note for the specified period and date.
+      operationId: patch_periodic_period_year_month_day
       tags:
         - "Periodic Notes"
     post:
@@ -1383,6 +1421,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Append content to the periodic note for the specified period and date.
+      operationId: post_periodic_period_year_month_day
       tags:
         - "Periodic Notes"
     put:
@@ -1451,6 +1490,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Update the content of the periodic note for the specified period and date.
+      operationId: put_periodic_period_year_month_day
       tags:
         - "Periodic Notes"
   /search/:
@@ -1572,6 +1612,7 @@ paths:
             Content-Type for your search query.
       summary: |
         Search for documents matching a specified search query
+      operationId: post_search
       tags:
         - "Search"
   /search/simple/:
@@ -1627,6 +1668,7 @@ paths:
           description: "Success"
       summary: |
         Search for documents matching a specified text query
+      operationId: post_search_simple
       tags:
         - "Search"
   /vault/:
@@ -1659,6 +1701,7 @@ paths:
           description: "Directory does not exist"
       summary: |
         List files that exist in the root of your vault.
+      operationId: get_vault
       tags:
         - "Vault Directories"
   "/vault/{filename}":
@@ -1690,6 +1733,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Delete a particular file in your vault.
+      operationId: delete_vault_filename
       tags:
         - "Vault Files"
     get:
@@ -1724,6 +1768,7 @@ paths:
           description: "File does not exist"
       summary: |
         Return the content of a single file in your vault.
+      operationId: get_vault_filename
       tags:
         - "Vault Files"
     patch:
@@ -1950,6 +1995,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Partially update content in an existing note.
+      operationId: patch_vault_filename
       tags:
         - "Vault Files"
     post:
@@ -1995,6 +2041,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Append content to a new or existing file.
+      operationId: post_vault_filename
       tags:
         - "Vault Files"
     put:
@@ -2042,6 +2089,7 @@ paths:
             Your path references a directory instead of a file; this request method is valid only for updating files.
       summary: |
         Create a new file in your vault or update the content of an existing one.
+      operationId: put_vault_filename
       tags:
         - "Vault Files"
   "/vault/{pathToDirectory}/":
@@ -2081,26 +2129,8 @@ paths:
           description: "Directory does not exist"
       summary: |
         List files that exist in the specified directory.
+      operationId: get_vault_pathToDirectory
       tags:
         - "Vault Directories"
 security:
   - apiKeyAuth: []
-servers:
-  - description: "HTTPS (Secure Mode)"
-    url: "https://{host}:{port}"
-    variables:
-      host:
-        default: "127.0.0.1"
-        description: "Binding host"
-      port:
-        default: "27124"
-        description: "HTTPS port"
-  - description: "HTTP (Insecure Mode)"
-    url: "http://{host}:{port}"
-    variables:
-      host:
-        default: "127.0.0.1"
-        description: "Binding host"
-      port:
-        default: "27123"
-        description: "HTTP port"


### PR DESCRIPTION
## Summary
- update OpenAPI version to 3.1.0 and add top level servers list
- add `operationId` to every operation in the spec

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684281af55948323ab59d5d0d1e1ea71