### PR TITLE
Fix openapi spec version

### DIFF
--- a/docs/src/openapi.jsonnet
+++ b/docs/src/openapi.jsonnet
@@ -13,7 +13,7 @@ local ParamYear = import 'year.param.jsonnet';
 
 std.manifestYamlDoc(
   {
-    openapi: '3.0.2',
+    openapi: '3.1.0',
     info: {
       title: 'Local REST API for Obsidian',
       description: "Interact with your Obsidian notes through this local REST API.\n\nPress the 'Authorize' button and supply your API key from plugin settings before sending requests. If your browser warns about the self-signed certificate, add it as a trusted certificate.",


### PR DESCRIPTION
## Summary
- align jsonnet spec version with generated docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844321c6a64832385217442b50a0905